### PR TITLE
Removed compiler warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "SymbolicReasoningEngine"
+name = "symbolic_reasoning_engine"
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "SymbolicReasoningEngine"
+name = "symbolic_reasoning_engine"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Compiler warnings are showing for code that is being used. RustRover doesn't show the same warnings. I'm assuming this is from being a Rust n00b and will review these soon.